### PR TITLE
update read-json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "closest-package": "^1.0.0",
     "object-assign": "^2.0.0",
     "read-closest-package": "^1.0.0",
-    "read-json": "^0.1.0",
+    "read-json": "^1.0.3",
     "run-series": "^1.1.0",
-    "spawn-npm-install": "^1.0.4"
+    "spawn-npm-install": "^1.2.0"
   },
   "devDependencies": {
     "tape": "^4.0.0"


### PR DESCRIPTION
`read-json` was [killed](https://medium.com/@azerbike/i-ve-just-liberated-my-modules-9045c06be67c#.37j7cvuek) and revived today with a major version bump. This is an update to that new major version, which I don't think has any code changes.

Once this fix lands we can update the [standardize](https://github.com/zeke/standardize) versions of `install-if-needed` and `read-json`.
